### PR TITLE
Feat/MAG-19: Static and shared library support

### DIFF
--- a/magnet/Source/Application.cpp
+++ b/magnet/Source/Application.cpp
@@ -65,6 +65,12 @@ namespace MG
 			bool commandExists = m_Commands.find(argument) != m_Commands.end();
 			if (commandExists)
 			{
+				if (!props.IsValid() && !CommandHandler::IsCommandGlobal(argument))
+				{
+					MG_LOG("It seems like there is no project in this folder, or the current configuration is corrupted. Try `magnet help` for more information.");
+					break;
+				}
+				
 				m_Commands.at(argument)(props);
 				continue;
 			}

--- a/magnet/Source/Application.cpp
+++ b/magnet/Source/Application.cpp
@@ -75,12 +75,6 @@ namespace MG
 				continue;
 			}
 
-			if (argument == "magnet" && !hasNext)
-			{
-				MG_LOG("No argument provided. Try `magnet help` for more information.");
-				continue;
-			}
-
 			bool hasPrevious = i - 1 >= 0;
 			if (!hasPrevious)
 				continue;
@@ -104,8 +98,10 @@ namespace MG
 			return "";
 
 		YAML::Node config = YAML::LoadFile(".magnet/config.yaml");
-		if (config["name"])
-			return config["name"].as<std::string>();
+
+		auto nameNode = config["name"];
+		if (nameNode)
+			return nameNode.as<std::string>();
 
 		return "";
 	}
@@ -116,8 +112,10 @@ namespace MG
 			return "";
 
 		YAML::Node config = YAML::LoadFile(".magnet/config.yaml");
-		if (config["projectType"])
-			return config["projectType"].as<std::string>();
+
+		auto projectTypeNode = config["projectType"];
+		if (projectTypeNode)
+			return projectTypeNode.as<std::string>();
 
 		return "";
 	}

--- a/magnet/Source/Application.cpp
+++ b/magnet/Source/Application.cpp
@@ -56,6 +56,12 @@ namespace MG
 			bool hasNext = i + 1 < m_Arguments.count;
 			std::string nextArgument = hasNext ? m_Arguments.list[i + 1] : "";
 
+			if (argument == "magnet" && !hasNext)
+			{
+				MG_LOG("No argument provided. Try `magnet help` for more information.");
+				continue;
+			}
+
 			CommandHandlerProps props;
 			props.projectName = projectName;
 			props.projectType = projectType;

--- a/magnet/Source/Application.cpp
+++ b/magnet/Source/Application.cpp
@@ -50,11 +50,16 @@ namespace MG
 			std::string argument = m_Arguments.list[i];
 
 			std::string projectName = Application::GetProjectName();
+			std::string projectType = Application::GetProjectType();
+			int cppVersion = Application::GetCppVersion();
+
 			bool hasNext = i + 1 < m_Arguments.count;
 			std::string nextArgument = hasNext ? m_Arguments.list[i + 1] : "";
 
 			CommandHandlerProps props;
 			props.projectName = projectName;
+			props.projectType = projectType;
+			props.cppVersion = cppVersion;
 			props.nextArgument = nextArgument;
 
 			bool commandExists = m_Commands.find(argument) != m_Commands.end();
@@ -109,6 +114,20 @@ namespace MG
 			return config["projectType"].as<std::string>();
 
 		return "";
+	}
+
+	int Application::GetCppVersion()
+	{
+		if (!IsRootLevel())
+			return -1;
+
+		YAML::Node config = YAML::LoadFile(".magnet/config.yaml");
+
+		auto cppDialectNode = config["cppDialect"];
+		if (cppDialectNode)
+			return cppDialectNode.as<int>();
+
+		return 0;
 	}
 
 	std::vector<std::string> Application::GetDependencies()

--- a/magnet/Source/Application.h
+++ b/magnet/Source/Application.h
@@ -25,6 +25,7 @@ namespace MG
 		static std::string GetCurrentWorkingDirectory();
 		static std::string GetProjectName();
 		static std::string GetProjectType();
+		static int GetCppVersion();
 		static std::vector<std::string> GetDependencies();
 		static bool IsRootLevel();
 

--- a/magnet/Source/CommandHandler.cpp
+++ b/magnet/Source/CommandHandler.cpp
@@ -279,6 +279,11 @@ namespace MG
 		HandleGenerateCommand(props);
 	}
 
+	bool CommandHandler::IsCommandGlobal(const std::string& command)
+	{
+		return command == "new" || command == "help";
+	}
+
 	void CommandHandler::CreateNewProject(const std::string& name, const std::string& type)
 	{
 		MG_LOG_HOST("Project Wizard", "Creating new C++ project...");

--- a/magnet/Source/CommandHandler.cpp
+++ b/magnet/Source/CommandHandler.cpp
@@ -48,19 +48,15 @@ namespace MG
 
 			if (!input.empty())
 			{
-				std::istringstream stream(input);
-				std::string chosenType;
-				stream >> chosenType;
-
-				switch (std::stoi(chosenType))
+				switch (input[0])
 				{
-					case 1:
+					case '1':
 						projectType = "Application";
 						break;
-					case 2:
+					case '2':
 						projectType = "StaticLibrary";
 						break;
-					case 3:
+					case '3':
 						projectType = "SharedLibrary";
 						break;
 					default:
@@ -68,7 +64,7 @@ namespace MG
 						continue;
 				}
 
-				MG_LOG_HOST("Project Wizard", "Invalid answer.");
+				break;
 			}
 			else
 				break;
@@ -389,7 +385,13 @@ target_include_directories(${PROJECT_NAME} PUBLIC "${PROJECT_SOURCE_DIR}/${PROJE
 		cmakeFile << "cmake_minimum_required(VERSION 3.16)\n";
 		cmakeFile << "project(" << props.projectName << ")\n";
 		cmakeFile << "set(CMAKE_CXX_STANDARD 17)\n";
-		cmakeFile << "add_executable(${PROJECT_NAME}";
+
+		if (Application::GetProjectType() == "StaticLibrary")
+			cmakeFile << "add_library(${PROJECT_NAME} STATIC";
+		else if (Application::GetProjectType() == "SharedLibrary")
+			cmakeFile << "add_library(${PROJECT_NAME} SHARED";
+		else
+			cmakeFile << "add_executable(${PROJECT_NAME}";
 
 		for (const auto& sourceFile : sourceFiles)
 		{

--- a/magnet/Source/CommandHandler.h
+++ b/magnet/Source/CommandHandler.h
@@ -33,6 +33,10 @@ namespace MG
 		static void HandlePullCommand(const CommandHandlerProps& props);
 		static void HandlePullListCommand(const CommandHandlerProps& props);
 		static void HandleRemoveCommand(const CommandHandlerProps& props);
+
+		// Returns whether the given command is global, meaning it doesn't
+		// require a project to be present.
+		static bool IsCommandGlobal(const std::string& command);
 	private:
 		// Creates a new project by initializing the template folder and
 		// generating a unique config.yaml file inside the .magnet folder.

--- a/magnet/Source/CommandHandler.h
+++ b/magnet/Source/CommandHandler.h
@@ -9,7 +9,15 @@ namespace MG
 	struct CommandHandlerProps
 	{
 		std::string projectName;
+		std::string projectType;
+		int cppVersion;
+
 		std::string nextArgument;
+
+		bool IsValid() const
+		{
+			return !projectName.empty() && !projectType.empty() && cppVersion != -1;
+		}
 	};
 
 	// Responsible for handling all of Magnet's command logic.


### PR DESCRIPTION
Currently, the prompt answers saved in config.yaml are not being used when generating the CMake files. This PR changes it and allows the creation of static as well as shared libraries.