### PR TITLE
Fixed UNIX link flags

### DIFF
--- a/magnet/Source/CommandHandler.cpp
+++ b/magnet/Source/CommandHandler.cpp
@@ -613,7 +613,7 @@ namespace MG
 		auto ifTrue = [&]()
 		{
 			emitter.Add_Indentation();
-			emitter.Add_SetTargetProperties(projectName, "LINK_FLAGS", "-Wl, -rpath, ./");
+			emitter.Add_SetTargetProperties(projectName, "LINK_FLAGS", "\"-Wl,-rpath,./\"");
 		};
 
 		auto ifFalse = [&]()


### PR DESCRIPTION
I had trouble building the stock example of magnet on my platform (EndavourOS Linux), it turns out that the linker flags are not properly escaped and result in empty files being added to the linker, escaping the flags with double quotes solves this problem.

This might solve issue #18, as my error messages were the same.