### PR TITLE
Feat/MAG-51: Ask for generator

### DIFF
--- a/magnet/Source/CommandHandler.h
+++ b/magnet/Source/CommandHandler.h
@@ -27,6 +27,7 @@ namespace MG
 		std::vector<std::string> nextArguments;
 
 		friend class Application;
+		friend class CommandHandler;
 	};
 
 	// Responsible for handling all of Magnet's command logic.
@@ -49,10 +50,13 @@ namespace MG
 		// Returns whether the given command is global, meaning it doesn't
 		// require a project to be present.
 		static bool IsCommandGlobal(const std::string& command);
+
 	private:
 		// Creates a new project by initializing the template folder and
 		// generating a unique config.yaml file inside the .magnet folder.
-		static void CreateNewProject(const Project& project);
+		// Immediately followed by generating all CMakeLists.txt files
+		// using the specified option and finally building the project.
+		static void CreateNewProject(const Project& project, const std::string& generator);
 
 		// Creates a CMakeLists.txt file at the root of the project.
 		static bool GenerateRootCMakeFile(const CommandHandlerProps& props);

--- a/magnet/Source/Platform/LinuxPlatform.cpp
+++ b/magnet/Source/Platform/LinuxPlatform.cpp
@@ -34,6 +34,11 @@ namespace MG
 		return p;
 	}
 
+	std::string Platform::GetGenerator()
+	{
+		return "Ninja";
+	}
+
 	std::string Platform::GetGenerateCommand(const std::string& configuration)
 	{
 		return "-DCMAKE_BUILD_TYPE=" + configuration + " ";

--- a/magnet/Source/Platform/Platform.h
+++ b/magnet/Source/Platform/Platform.h
@@ -10,9 +10,13 @@ namespace MG
 		// Returns the real path to the executable. Does not include the executable name.
 		static std::filesystem::path GetExecutablePath();
 
+		// Returns the default generator for the current platform.
+		static std::string GetGenerator();
+
 		// Returns the CMake generator command for the current platform.
 		static std::string GetGenerateCommand(const std::string& configuration);
 
+		// Returns the command for launching the application.
 		static std::string GetGoCommand(const std::string& appPath);
 	};
 }

--- a/magnet/Source/Platform/WindowsPlatform.cpp
+++ b/magnet/Source/Platform/WindowsPlatform.cpp
@@ -21,9 +21,14 @@ namespace MG
 		return p;
 	}
 
+	std::string Platform::GetGenerator()
+	{
+		return "\"Visual Studio 17 2022\"";
+	}
+
 	std::string Platform::GetGenerateCommand([[maybe_unused]] const std::string& configuration)
 	{
-		return "-G \"Visual Studio 17 2022\" -A x64";
+		return "-A x64";
 	}
 
 	std::string Platform::GetGoCommand(const std::string& appPath)

--- a/magnet/Source/Platform/macOSPlatform.cpp
+++ b/magnet/Source/Platform/macOSPlatform.cpp
@@ -31,6 +31,11 @@ namespace MG
 		return p;
 	}
 
+	std::string Platform::GetGenerator()
+	{
+		return "Xcode";
+	}
+
 	std::string Platform::GetGenerateCommand(const std::string& configuration)
 	{
 		return "-DCMAKE_BUILD_TYPE=" + configuration + " ";


### PR DESCRIPTION
# Description

Instead of inferring the generator every time the user runs `magnet generate`, it is better to ask the user for this option upon project creation. This also allows passing down a custom generator flag on clean projects: `magnet generate -G Xcode`.

# Checklist

- [x] 👀 I did a self-review of my own code
- [x] 📚 I added necessary documentation (if appropriate)
- [x] 🧪 I tested my code
